### PR TITLE
Update debt payoff widget

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,5 @@
 """Widget support code, mostly backend data structures and math. """
+from copy import deepcopy
 from typing import Iterable, List, Tuple, Union
 from matplotlib.lines import Line2D
 from matplotlib import pyplot as plt
@@ -24,7 +25,7 @@ class LineGraph:
         for i_line, line in enumerate(self.lines):
             yield i_line, line
 
-    def plot(self, *args, **kwargs) -> bool:
+    def plot(self, *args, metadata: dict = None, **kwargs) -> bool:
         """Plot a new line.
 
         Args:
@@ -36,13 +37,16 @@ class LineGraph:
         if len(self.lines) == self.max_lines:
             return False
         self.lines.append(self.axes.plot(*args, **kwargs)[0])
+        if metadata is not None:
+            self.lines[-1].metadata = deepcopy(metadata)
         self.select(self.num_lines - 1)
         return True
 
     def update(
         self,
         xdata: Iterable[Numeric],
-        ydata: Iterable[Numeric]
+        ydata: Iterable[Numeric],
+        metadata: dict
     ) -> bool:
         """Update the currently-selected line.
 
@@ -56,6 +60,7 @@ class LineGraph:
         if self.num_lines == 0:
             return False
         self.lines[self.selected].set_data(xdata, ydata)
+        self.lines[self.selected].metadata = deepcopy(metadata)
         self.axes.relim()
         self.axes.autoscale()
         self.fig.canvas.draw()

--- a/widgets.py
+++ b/widgets.py
@@ -102,17 +102,6 @@ class DebtPayoffWidget(ttk.Frame):
         super().__init__(*args, **kwargs)
         self.linegraph = utils.LineGraph()
 
-        # initial candidate line
-        _, running_balance = utils.calc_balance_over_time(
-            balance=1000,
-            payment=25,
-            apr=25
-        )
-        self.linegraph.plot(
-            running_balance, '.-', picker=5,
-            metadata={'balance': 1000, 'payment': 25, 'apr': 25}
-        )
-
         # graph annotations
         self.linegraph.axes.set_title('Debt Payoff Schedule')
         self.linegraph.axes.grid()
@@ -145,11 +134,31 @@ class DebtPayoffWidget(ttk.Frame):
         self.payment.pack(padx=2, pady=2, fill=tk.X)
         self.payment.add_trace(self.entry_change_callback)
 
-        # monthly payment
+        # annual percentage rate (APR)
         self.apr = NaturalNumberEntry(self)
         self.apr.set_text('APR')
         self.apr.pack(padx=2, pady=2, fill=tk.X)
         self.apr.add_trace(self.entry_change_callback)
+
+        # add button
+        self.add_button = ttk.Button(
+            self,
+            text='New line',
+            command=self.add_candidate_line
+        )
+        self.add_button.pack(padx=2, pady=2, fill=tk.X)
+
+    def add_candidate_line(self) -> None:
+        """Add a new candiate line to the graph. """
+        _, running_balance = utils.calc_balance_over_time(
+            balance=1000,
+            payment=25,
+            apr=25
+        )
+        self.linegraph.plot(
+            running_balance, '.-', picker=5,
+            metadata={'balance': 1000, 'payment': 25, 'apr': 25}
+        )
 
     def entry_change_callback(self, _) -> None:
         """Update currently-selected line. """

--- a/widgets.py
+++ b/widgets.py
@@ -126,7 +126,7 @@ class DebtPayoffWidget(ttk.Frame):
         self.balance = NaturalNumberEntry(self)
         self.balance.set_text('Balance')
         self.balance.pack(padx=2, pady=2, fill=tk.X)
-        self.balance.add_trace(self.entry_change_callback)
+        # self.balance.add_trace(self.entry_change_callback)
 
         # monthly payment
         self.payment = NaturalNumberEntry(self)
@@ -138,7 +138,7 @@ class DebtPayoffWidget(ttk.Frame):
         self.apr = NaturalNumberEntry(self)
         self.apr.set_text('APR')
         self.apr.pack(padx=2, pady=2, fill=tk.X)
-        self.apr.add_trace(self.entry_change_callback)
+        # self.apr.add_trace(self.entry_change_callback)
 
         # add button
         self.add_button = ttk.Button(

--- a/widgets.py
+++ b/widgets.py
@@ -88,27 +88,11 @@ class DebtPayoffWidget(ttk.Frame):
         super().__init__(*args, **kwargs)
         self.linegraph = utils.LineGraph()
 
-        # scenario 1
+        # initial candidate line
         _, running_balance = utils.calc_balance_over_time(
             balance=1000,
-            payment=50,
+            payment=25,
             apr=25
-        )
-        self.linegraph.plot(running_balance, '.-', picker=5)
-
-        # scenario 2
-        _, running_balance = utils.calc_balance_over_time(
-            balance=1000,
-            payment=100,
-            apr=25
-        )
-        self.linegraph.plot(running_balance, '.-', picker=5)
-
-        # scenario 3
-        _, running_balance = utils.calc_balance_over_time(
-            balance=1000,
-            payment=50,
-            apr=20
         )
         self.linegraph.plot(running_balance, '.-', picker=5)
 


### PR DESCRIPTION
"New line" button introduced (alpha) for debt payoff widget. Entry callbacks limited to just the payment entry callback (bug details below).

Multiple graph lines have shown that line selection results in de-synced entry callbacks calls when the line metadata is loaded back into the entry UI elements one-by-one. Basically, updating the UI with the line metadata causes the UI to update the line with bad metadata and push it bad metadata.